### PR TITLE
Order guessable characters by frequency order

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,7 +5,7 @@ import Jimp from 'jimp';
 import * as path from "path";
 
 // Some hardcoded constants here.
-const guessable_characters = 'abcdefghijklmnopqrstuvwxyz ';
+const guessable_characters = 'etaoinshrdlucmfwgypbvkxjqz ';
 const max_length = 20;
 const blocksize = 8;
 const threshold = 0.25;


### PR DESCRIPTION
Hello,

reordering the guessable characters should significantly improve the decoding speed for english words. The demo GIF should be even more convincing then :)